### PR TITLE
Fix cancelled awards check

### DIFF
--- a/openprocurement/tender/limited/tests/award.py
+++ b/openprocurement/tender/limited/tests/award.py
@@ -1650,9 +1650,8 @@ class TenderLotNegotiationAwardComplaintResourceTest(TenderNegotiationAwardCompl
         response = self.app.get('/tenders/{}/contracts?acc_token={}'.format(self.tender_id, self.tender_token))
 
         self.assertEqual(response.status, '200 OK')
-
-        for contract in response.json['data']:
-            self.assertEqual(contract['status'], 'cancelled')
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data']['status'], 'cancelled')
 
 
 class Tender2LotNegotiationAwardComplaintResourceTest(BaseTenderContentWebTest):

--- a/openprocurement/tender/limited/tests/award.py
+++ b/openprocurement/tender/limited/tests/award.py
@@ -3,7 +3,8 @@ import unittest
 
 from openprocurement.tender.limited.tests.base import (
     BaseTenderContentWebTest, test_tender_data, test_tender_negotiation_data,
-    test_tender_negotiation_quick_data, test_organization, test_lots)
+    test_tender_negotiation_quick_data, test_organization, test_lots,
+    test_tender_negotiation_data_2items, test_tender_negotiation_quick_data_2items)
 
 
 class TenderAwardResourceTest(BaseTenderContentWebTest):
@@ -1463,6 +1464,82 @@ class TenderNegotiationAwardComplaintResourceTest(BaseTenderContentWebTest):
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(response.json['errors'][0]["description"], "Can add complaint only in complaintPeriod")
 
+    def test_cancelled_award_with_complaint(self):
+        """ When complaint on award in satisfied status and owner cancel award,
+            then all awards and contracts must move to status cancelled """
+
+        # Move award to unsuccessful
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'unsuccessful'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'unsuccessful')
+
+        # Create another award
+        self.create_award()
+
+        # Activate award
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'active'}})
+
+        # Create complaint
+        response = self.app.post_json('/tenders/{}/awards/{}/complaints'.format(self.tender_id, self.award_id),
+                                      {'data': {'title': 'complaint title', 'description': 'complaint description',
+                                                'author': test_organization, 'status': 'pending'}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        complaint = response.json['data']
+
+        # Move complaint to satisfied
+        self.app.authorization = ('Basic', ('reviewer', ''))
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id']),
+            {'data': {'status': 'accepted'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'accepted')
+
+        # Make decision
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id']), {"data": {"decision": 'satisfied complaint'}})
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['data']["decision"], 'satisfied complaint')
+
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id'], self.tender_token),
+            {'data': {'status': 'satisfied'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'satisfied')
+
+        # Active award and then cancel it
+        self.app.authorization = ('Basic', ('broker', ''))
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'cancelled'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'cancelled')
+
+        # Let's check another award
+
+        response = self.app.get('/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+        for award in response.json['data']:
+            self.assertEqual(award['status'], 'cancelled')
+
+        # And check contracts
+        response = self.app.get('/tenders/{}/contracts?acc_token={}'.format(self.tender_id, self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+
+        for contract in response.json['data']:
+            self.assertEqual(contract['status'], 'cancelled')
+
 
 class TenderLotNegotiationAwardComplaintResourceTest(TenderNegotiationAwardComplaintResourceTest):
 
@@ -1472,15 +1549,362 @@ class TenderLotNegotiationAwardComplaintResourceTest(TenderNegotiationAwardCompl
                                       {'data': test_lots[0]})
         self.assertEqual(response.status, '201 Created')
         self.assertEqual(response.content_type, 'application/json')
-        lot = response.json['data']
+        self.lot = response.json['data']
+
+        # set items to lot
+        response = self.app.patch_json('/tenders/{}?acc_token={}'.format(self.tender_id, self.tender_token),
+                                       {
+                                           "data": {
+                                               "items": [
+                                                   {
+                                                       "relatedLot": self.lot['id']
+                                                   }
+                                               ]
+                                           }
+                                       })
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['items'][0]['relatedLot'], self.lot['id'])
+
         # create award
         request_path = '/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token)
         response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization], 'qualified': True,
-                                                              'status': 'pending', 'lotID': lot['id']}})
+                                                              'status': 'pending', 'lotID': self.lot['id']}})
         self.assertEqual(response.status, '201 Created')
         self.assertEqual(response.content_type, 'application/json')
         award = response.json['data']
         self.award_id = award['id']
+
+    def test_cancelled_award_with_complaint(self):
+        """ When complaint on award in satisfied status and owner cancel award,
+            then all awards (with same lotID) and contracts must move to status cancelled """
+
+        # Move award to unsuccessful
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'unsuccessful'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'unsuccessful')
+
+        # Create another award
+        request_path = '/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token)
+        response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization], 'qualified': True,
+                                                              'status': 'pending', 'lotID': self.lot['id']}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        award = response.json['data']
+        self.award_id = award['id']
+
+        # Activate award
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'active'}})
+
+        # Create complaint
+        response = self.app.post_json('/tenders/{}/awards/{}/complaints'.format(self.tender_id, self.award_id),
+                                      {'data': {'title': 'complaint title', 'description': 'complaint description',
+                                                'author': test_organization, 'status': 'pending'}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        complaint = response.json['data']
+
+        # Move complaint to satisfied
+        self.app.authorization = ('Basic', ('reviewer', ''))
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id']),
+            {'data': {'status': 'accepted'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'accepted')
+
+        # Make decision
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id']), {"data": {"decision": 'satisfied complaint'}})
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['data']["decision"], 'satisfied complaint')
+
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id'], self.tender_token),
+            {'data': {'status': 'satisfied'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'satisfied')
+
+        # Active award and then cancel it
+        self.app.authorization = ('Basic', ('broker', ''))
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'cancelled'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'cancelled')
+
+        # Let's check another award
+
+        response = self.app.get('/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+        for award in response.json['data']:
+            self.assertEqual(award['status'], 'cancelled')
+
+        # And check contracts
+        response = self.app.get('/tenders/{}/contracts?acc_token={}'.format(self.tender_id, self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+
+        for contract in response.json['data']:
+            self.assertEqual(contract['status'], 'cancelled')
+
+
+class Tender2LotNegotiationAwardComplaintResourceTest(BaseTenderContentWebTest):
+    initial_data = test_tender_negotiation_data_2items
+
+    def setUp(self):
+        super(Tender2LotNegotiationAwardComplaintResourceTest, self).setUp()
+        self.create_award()
+
+    def create_award(self):
+        # create lots
+        response = self.app.post_json('/tenders/{}/lots?acc_token={}'.format(self.tender_id, self.tender_token),
+                                      {'data': test_lots[0]})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        self.first_lot = response.json['data']
+
+        self.assertEqual(response.content_type, 'application/json')
+        response = self.app.post_json('/tenders/{}/lots?acc_token={}'.format(self.tender_id, self.tender_token),
+                                      {'data': test_lots[0]})
+        self.assertEqual(response.status, '201 Created')
+        self.second_lot = response.json['data']
+
+        # set items to lot
+        response = self.app.patch_json('/tenders/{}?acc_token={}'.format(self.tender_id, self.tender_token),
+                                       {
+                                           "data": {
+                                               "items": [
+                                                   {"relatedLot": self.first_lot['id']},
+                                                   {"relatedLot": self.second_lot['id']}
+                                               ]
+                                           }
+                                       })
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['items'][0]['relatedLot'], self.first_lot['id'])
+        self.assertEqual(response.json['data']['items'][1]['relatedLot'], self.second_lot['id'])
+
+        # create first award
+        request_path = '/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token)
+        response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization], 'qualified': True,
+                                                              'status': 'pending', 'lotID': self.first_lot['id']}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        self.first_award = response.json['data']
+        self.award_id = self.first_award['id']
+
+        # create second award
+        request_path = '/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token)
+        response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization], 'qualified': True,
+                                                              'status': 'pending', 'lotID': self.second_lot['id']}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        self.second_award = response.json['data']
+        self.second_award_id = self.second_award['id']
+
+    def test_cancelled_award_with_complaint(self):
+        """ When complaint on award in satisfied status and owner cancel award,
+            then all awards (with same lotID) and contracts must move to status cancelled """
+
+        # Move first award to unsuccessful
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'unsuccessful'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'unsuccessful')
+
+        # Create another award
+        request_path = '/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token)
+        response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization], 'qualified': True,
+                                                              'status': 'pending', 'lotID': self.first_lot['id']}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        award = response.json['data']
+        self.award_id = award['id']
+
+        # Activate first award
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'active'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'active')
+
+        # Activate second award
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.second_award_id, self.tender_token),
+            {'data': {'status': 'active'}})
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'active')
+
+        # Create complaint on first award
+        response = self.app.post_json('/tenders/{}/awards/{}/complaints'.format(self.tender_id, self.award_id),
+                                      {'data': {'title': 'complaint title', 'description': 'complaint description',
+                                                'author': test_organization, 'status': 'pending'}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        complaint = response.json['data']
+
+        # Move complaint to satisfied
+        self.app.authorization = ('Basic', ('reviewer', ''))
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id']),
+            {'data': {'status': 'accepted'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'accepted')
+
+        # Make decision
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id']), {"data": {"decision": 'satisfied complaint'}})
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['data']["decision"], 'satisfied complaint')
+
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id'], self.tender_token),
+            {'data': {'status': 'satisfied'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'satisfied')
+
+        # Active award and then cancel it
+        self.app.authorization = ('Basic', ('broker', ''))
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'cancelled'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'cancelled')
+
+        # Let's check another award
+
+        response = self.app.get('/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+        for award in response.json['data']:
+            if award['lotID'] == self.first_award['lotID']:
+                self.assertEqual(award['status'], 'cancelled')
+            else:
+                self.assertEqual(award['status'], 'active')
+
+        # And check contracts
+        response = self.app.get('/tenders/{}/contracts?acc_token={}'.format(self.tender_id, self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+
+        for contract in response.json['data']:
+            if contract['awardID'] == self.first_award['id']:
+                self.assertEqual(contract['status'], 'cancelled')
+            if contract['awardID'] == self.second_award['id']:
+                self.assertEqual(contract['status'], 'pending')
+
+    def test_cancelled_unsuccessful_award_with_complaint(self):
+        """ When complaint on award in satisfied status and owner cancel award,
+            then all awards (with same lotID) and contracts must move to status cancelled """
+
+        # Move first award to unsuccessful
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'unsuccessful'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'unsuccessful')
+
+        # Create another award
+        request_path = '/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token)
+        response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization], 'qualified': True,
+                                                              'status': 'pending', 'lotID': self.first_lot['id']}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        award = response.json['data']
+        self.award_id = award['id']
+
+        # Activate second award
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.second_award_id, self.tender_token),
+            {'data': {'status': 'active'}})
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'active')
+
+        # Create complaint on first award
+        response = self.app.post_json('/tenders/{}/awards/{}/complaints'.format(self.tender_id, self.award_id),
+                                      {'data': {'title': 'complaint title', 'description': 'complaint description',
+                                                'author': test_organization, 'status': 'pending'}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        complaint = response.json['data']
+
+        # Move complaint to satisfied
+        self.app.authorization = ('Basic', ('reviewer', ''))
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id']),
+            {'data': {'status': 'accepted'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'accepted')
+
+        # Make decision
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id']), {"data": {"decision": 'satisfied complaint'}})
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['data']["decision"], 'satisfied complaint')
+
+        response = self.app.patch_json('/tenders/{}/awards/{}/complaints/{}'.format(
+            self.tender_id, self.award_id, complaint['id'], self.tender_token),
+            {'data': {'status': 'satisfied'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'satisfied')
+
+        # Move to unsuccessful award
+        self.app.authorization = ('Basic', ('broker', ''))
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'unsuccessful'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'unsuccessful')
+        # Cancel award
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token),
+            {'data': {'status': 'cancelled'}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'cancelled')
+
+        # Let's check another award
+        response = self.app.get('/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+        for award in response.json['data']:
+            if award['lotID'] == self.first_award['lotID']:
+                self.assertEqual(award['status'], 'cancelled')
+            else:
+                self.assertEqual(award['status'], 'active')
+
+        # And check contracts
+        response = self.app.get('/tenders/{}/contracts?acc_token={}'.format(self.tender_id, self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+
+        for contract in response.json['data']:
+            self.assertEqual(contract['status'], 'pending')
+
+
+class Tender2LotNegotiationQuickAwardComplaintResourceTest(Tender2LotNegotiationAwardComplaintResourceTest):
+    initial_data = test_tender_negotiation_quick_data_2items
 
 
 class TenderNegotiationQuickAwardComplaintResourceTest(TenderNegotiationAwardComplaintResourceTest):

--- a/openprocurement/tender/limited/tests/award.py
+++ b/openprocurement/tender/limited/tests/award.py
@@ -1792,16 +1792,21 @@ class Tender2LotNegotiationAwardComplaintResourceTest(BaseTenderContentWebTest):
         self.assertEqual(response.status, '200 OK')
         self.assertEqual(response.json['data']['status'], 'cancelled')
 
-        # Let's check another award
+        # Let's awards
 
-        response = self.app.get('/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token))
+        response = self.app.get('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.first_award['id'], self.tender_token))
 
         self.assertEqual(response.status, '200 OK')
-        for award in response.json['data']:
-            if award['lotID'] == self.first_award['lotID']:
-                self.assertEqual(award['status'], 'cancelled')
-            else:
-                self.assertEqual(award['status'], 'active')
+        self.assertEqual(response.json['data']['lotID'], self.first_award['lotID'])
+        self.assertEqual(response.json['data']['status'], 'cancelled')
+
+        response = self.app.get('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.second_award['id'], self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['lotID'], self.second_award['lotID'])
+        self.assertEqual(response.json['data']['status'], 'active')
 
         # And check contracts
         response = self.app.get('/tenders/{}/contracts?acc_token={}'.format(self.tender_id, self.tender_token))

--- a/openprocurement/tender/limited/tests/award.py
+++ b/openprocurement/tender/limited/tests/award.py
@@ -1580,7 +1580,7 @@ class TenderLotNegotiationAwardComplaintResourceTest(TenderNegotiationAwardCompl
         response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
             self.tender_id, self.award_id, self.tender_token),
             {'data': {'status': 'unsuccessful'}})
-
+        self.old_award_id = self.award_id
         self.assertEqual(response.status, '200 OK')
         self.assertEqual(response.json['data']['status'], 'unsuccessful')
 
@@ -1640,18 +1640,26 @@ class TenderLotNegotiationAwardComplaintResourceTest(TenderNegotiationAwardCompl
 
         # Let's check another award
 
-        response = self.app.get('/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token))
+        response = self.app.get('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.award_id, self.tender_token))
 
         self.assertEqual(response.status, '200 OK')
-        for award in response.json['data']:
-            self.assertEqual(award['status'], 'cancelled')
+        self.assertEqual(response.json['data']['status'], 'cancelled')
+        self.assertEqual(response.json['data']['lotID'], self.lot['id'])
+
+        response = self.app.get('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, self.old_award_id, self.tender_token))
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['status'], 'cancelled')
+        self.assertEqual(response.json['data']['lotID'], self.lot['id'])
 
         # And check contracts
         response = self.app.get('/tenders/{}/contracts?acc_token={}'.format(self.tender_id, self.tender_token))
 
         self.assertEqual(response.status, '200 OK')
         self.assertEqual(len(response.json['data']), 1)
-        self.assertEqual(response.json['data']['status'], 'cancelled')
+        self.assertEqual(response.json['data'][0]['status'], 'cancelled')
 
 
 class Tender2LotNegotiationAwardComplaintResourceTest(BaseTenderContentWebTest):

--- a/openprocurement/tender/limited/tests/award.py
+++ b/openprocurement/tender/limited/tests/award.py
@@ -1536,7 +1536,7 @@ class TenderNegotiationAwardComplaintResourceTest(BaseTenderContentWebTest):
 
         self.assertEqual(response.status, '200 OK')
         self.assertEqual(len(response.json['data']), 1)
-        self.assertEqual(response.json['data']['status'], 'cancelled')
+        self.assertEqual(response.json['data'][0]['status'], 'cancelled')
 
 
 class TenderLotNegotiationAwardComplaintResourceTest(TenderNegotiationAwardComplaintResourceTest):
@@ -1982,9 +1982,8 @@ class Tender2LotNegotiationAwardComplaintResourceTest(BaseTenderContentWebTest):
         response = self.app.get('/tenders/{}/contracts?acc_token={}'.format(self.tender_id, self.tender_token))
 
         self.assertEqual(response.status, '200 OK')
-
-        for contract in response.json['data']:
-            self.assertEqual(contract['status'], 'pending')
+        self.assertEqual(len(response.json['data']), 1)
+        self.assertEqual(response.json['data'][0]['status'], 'pending')
 
 
 class Tender2LotNegotiationQuickAwardComplaintResourceTest(Tender2LotNegotiationAwardComplaintResourceTest):

--- a/openprocurement/tender/limited/tests/base.py
+++ b/openprocurement/tender/limited/tests/base.py
@@ -27,11 +27,20 @@ test_tender_negotiation_data['causeDescription'] = "chupacabra"
 if SANDBOX_MODE:
     test_tender_negotiation_data['procurementMethodDetails'] = 'quick, accelerator=1440'
 
+test_tender_negotiation_data_2items = deepcopy(test_tender_negotiation_data)
+test_tender_negotiation_data_2items['items'] = [deepcopy(test_tender_negotiation_data_2items['items'][0]),
+                                                deepcopy(test_tender_negotiation_data_2items['items'][0])]
+
 test_tender_negotiation_quick_data = deepcopy(test_tender_data)
 test_tender_negotiation_quick_data['procurementMethodType'] = "negotiation.quick"
 test_tender_negotiation_quick_data['causeDescription'] = "chupacabra"
 if SANDBOX_MODE:
     test_tender_negotiation_quick_data['procurementMethodDetails'] = 'quick, accelerator=1440'
+
+
+test_tender_negotiation_quick_data_2items = deepcopy(test_tender_negotiation_quick_data)
+test_tender_negotiation_quick_data_2items['items'] = [deepcopy(test_tender_negotiation_quick_data_2items['items'][0]),
+                                                      deepcopy(test_tender_negotiation_quick_data_2items['items'][0])]
 
 test_lots = [
     {

--- a/openprocurement/tender/limited/views/award.py
+++ b/openprocurement/tender/limited/views/award.py
@@ -557,12 +557,17 @@ class TenderNegotiationAwardResource(TenderAwardResource):
             # add_next_award(self.request)
         elif award_status == 'unsuccessful' and award.status == 'cancelled' and any([i.status == 'satisfied' for i in award.complaints]):
             now = get_now()
+            cancelled_awards = []
             for i in tender.awards:
-                if i.complaintPeriod.endDate > now:
+                if i.lotID != award.lotID:
+                    continue
+                if not i.complaintPeriod.endDate or i.complaintPeriod.endDate > now:
                     i.complaintPeriod.endDate = now
                 i.status = 'cancelled'
+                cancelled_awards.append(i.id)
             for i in tender.contracts:
-                i.status = 'cancelled'
+                if i.awardID in cancelled_awards:
+                    i.status = 'cancelled'
         elif award_status != award.status:
             self.request.errors.add('body', 'data', 'Can\'t update award in current ({}) status'.format(award_status))
             self.request.errors.status = 403

--- a/openprocurement/tender/limited/views/award.py
+++ b/openprocurement/tender/limited/views/award.py
@@ -533,12 +533,17 @@ class TenderNegotiationAwardResource(TenderAwardResource):
             # add_next_award(self.request)
         elif award_status == 'active' and award.status == 'cancelled' and any([i.status == 'satisfied' for i in award.complaints]):
             now = get_now()
+            cancelled_awards = []
             for i in tender.awards:
-                if i.complaintPeriod.endDate > now:
+                if i.lotID != award.lotID:
+                    continue
+                if not i.complaintPeriod.endDate or i.complaintPeriod.endDate > now:
                     i.complaintPeriod.endDate = now
                 i.status = 'cancelled'
+                cancelled_awards.append(i.id)
             for i in tender.contracts:
-                i.status = 'cancelled'
+                if i.awardID in cancelled_awards:
+                    i.status = 'cancelled'
         elif award_status == 'active' and award.status == 'cancelled':
             now = get_now()
             if award.complaintPeriod.endDate > now:


### PR DESCRIPTION
Якщо на award подається complaint і він буде переведений в статус satisfied, то замовник може скасувати рішення з цього Авард (тоді він і все awards переводяться в cancelled) у рамках лоту.

PS: За основу взяв логіку з openua.

- [x] * задоволення скарги на Award, переведе всі Award i Contract в cancelled

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.tender.limited/60)
<!-- Reviewable:end -->
